### PR TITLE
Remove CNAME so that sarahgwin.com can be reused

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.sarahgwin.com


### PR DESCRIPTION
I'm planning to use sarahgwin.com for my personal website. GitHub Pages only allows one CNAME per domain name.
https://docs.github.com/en/github/working-with-github-pages/troubleshooting-custom-domains-and-github-pages#cname-errors